### PR TITLE
testing sequential upserts for UUID consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "is-plain-object": "^3",
     "json-stringify-safe": "^5",
     "lodash.defaults": "^4",
-    "sequelize": "^6"
+    "sequelize": "^5"
   },
   "scripts": {
     "start": "cross-env LOCAL_SSCCE=true DIALECT=sqlite node setup/runner.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "is-plain-object": "^3",
     "json-stringify-safe": "^5",
     "lodash.defaults": "^4",
-    "sequelize": "^5"
+    "sequelize": "^6"
   },
   "scripts": {
     "start": "cross-env LOCAL_SSCCE=true DIALECT=sqlite node setup/runner.js",

--- a/src/sscce.js
+++ b/src/sscce.js
@@ -24,8 +24,8 @@ module.exports = async function () {
     });
 
     const Foo = sequelize.define('Foo', {
-        id: { type: DT.UUID, defaultValue: DT.UUIDV4, primaryKey: true },
-        name: { type: DT.STRING, allowNull: false, unique: true }
+        id: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4, primaryKey: true },
+        name: { type: DataTypes.STRING, allowNull: false, unique: true }
     });
 
     await sequelize.sync();

--- a/src/sscce.js
+++ b/src/sscce.js
@@ -1,4 +1,5 @@
 'use strict';
+if (process.env.DIALECT !== "postgres") return;
 
 // Require the necessary things from Sequelize
 const { Sequelize, Op, Model, DataTypes } = require('sequelize');


### PR DESCRIPTION
Doing two upserts in a row using a UUID seems to result in the second response bringing back a different UUID, when the expectation would be to bring back the original ID.