### PR TITLE
Added failing test for when calling `findAndCountAll` method with a virtual column that is included in the having clause

### DIFF
--- a/src/sscce-sequelize-6.ts
+++ b/src/sscce-sequelize-6.ts
@@ -36,6 +36,16 @@ export async function run() {
   await sequelize.sync({ force: true });
   expect(spy).to.have.been.called;
 
-  console.log(await Foo.create({ name: 'TS foo' }));
-  expect(await Foo.count()).to.equal(1);
+  console.log(await Foo.create({ name: "foo" }));
+
+  // When using `findAndCountAll` method, the virtual column gets removed, hence it's not possible to apply a condition on that column
+  expect(
+    await Foo.findAndCountAll({
+      attributes: [
+        [sequelize.fn("length", sequelize.col("name")), "nameLength"],
+      ],
+      group: ["name"],
+      having: { nameLength: 3 },
+    })
+  ).to.equal(1);
 }

--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -36,6 +36,16 @@ export async function run() {
   await sequelize.sync({ force: true });
   expect(spy).to.have.been.called;
 
-  console.log(await Foo.create({ name: 'TS foo' }));
-  expect(await Foo.count()).to.equal(1);
+  console.log(await Foo.create({ name: "foo" }));
+
+  // When using `findAndCountAll` method, the virtual column gets removed, hence it's not possible to apply a condition on that column
+  expect(
+    await Foo.findAndCountAll({
+      attributes: [
+        [sequelize.fn("length", sequelize.col("name")), "nameLength"],
+      ],
+      group: ["name"],
+      having: { nameLength: 3 },
+    })
+  ).to.equal(1);
 }


### PR DESCRIPTION
When using `findAndCountAll` method, it's not possible to define a virtual column (through `attributes` option) and at the same time include that virtual column inside the `having` clause of the query because when `sequelize` builds the count query the virtual column gets removed from the actual query.

Related to: https://github.com/sequelize/sequelize/issues/9747