### PR TITLE
Repro case for scoped findAndCountAll failure

### DIFF
--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -21,21 +21,40 @@ export async function run() {
     },
   });
 
-  class Foo extends Model {}
+ class FooModel extends Model {}
 
-  Foo.init({
-    name: DataTypes.TEXT,
-  }, {
-    sequelize,
-    modelName: 'Foo',
+  FooModel.init(
+    {
+      id: {type: DataTypes.STRING, primaryKey: true}
+    },
+    {sequelize, modelName: 'FooModel'}
+  );
+
+  await FooModel.sync();
+
+  class OtherModel extends Model {}
+
+  OtherModel.init(
+    {
+      id: {type: DataTypes.STRING, primaryKey: true},
+      modelId: {type: DataTypes.STRING, field: 'model_id'},
+      modelType: {type: DataTypes.ENUM('foo', 'bar'), field: 'model_type'}
+    },
+    {sequelize, modelName: 'OtherModel'}
+  );
+
+  await OtherModel.sync();
+
+  FooModel.hasMany(OtherModel, {
+    foreignKey: 'modelId',
+    scope: {
+      modelType: 'foo'
+    }
   });
 
-  // You can use sinon and chai assertions directly in your SSCCE.
-  const spy = sinon.spy();
-  sequelize.afterBulkSync(() => spy());
-  await sequelize.sync({ force: true });
-  expect(spy).to.have.been.called;
-
-  console.log(await Foo.create({ name: 'TS foo' }));
-  expect(await Foo.count()).to.equal(1);
+  await FooModel.findAndCountAll({
+    include: {
+      model: OtherModel
+    }
+  });
 }


### PR DESCRIPTION
I have two models (in the example, `FooModel` and `OtherModel`). `FooModel` has a `hasMany` association with `OtherModel`, with a scope that references an aliased column (i.e. a DB column with a different name from the model attribute).

Selecting `FooModel` instances using `findAll` and including `OtherModel` works as expected. However, when using `findAndCountAll`, invalid SQL is generated, because the column alias is not resolved, and the query fails with an error:

```
DatabaseError [SequelizeDatabaseError]: SQLITE_ERROR: no such column: OtherModels.modelType
```