### PR TITLE
Primary key of type DATE yields missing rows when using options.include if values only differs by milliseconds (same second)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "license": "MIT",
   "dependencies": {
+    "@sequelize/core": "^7.0.0-alpha.10",
     "chai": "^4",
     "chai-as-promised": "^7",
     "chai-datetime": "^1",
@@ -13,7 +14,7 @@
     "cross-env": "^7",
     "fs-jetpack": "^4",
     "sequelize": "^6",
-    "@sequelize/core": "^7.0.0-alpha.10",
+    "sequelize-typescript": "^2.1.5",
     "sinon": "^13",
     "sinon-chai": "^3"
   },
@@ -50,6 +51,7 @@
     "del-cli": "^4",
     "eslint": "^8",
     "lodash": "^4.17.21",
+    "reflect-metadata": "^0.1.13",
     "sqlite3": "^5",
     "ts-node": "^10.4.0",
     "typescript": "~4.5"

--- a/setup/create-sequelize-instance.ts
+++ b/setup/create-sequelize-instance.ts
@@ -1,5 +1,5 @@
 import type { Options as Sequelize6Options } from 'sequelize';
-import { Sequelize as Sequelize6 } from 'sequelize';
+import { Sequelize as Sequelize6 } from 'sequelize-typescript';
 import type { Options as Sequelize7Options, Sequelize as Sequelize7 } from '@sequelize/core';
 import { wrapOptions } from './wrap-options';
 

--- a/src/sscce-sequelize-6.ts
+++ b/src/sscce-sequelize-6.ts
@@ -1,41 +1,67 @@
-import { DataTypes, Model } from 'sequelize';
-import { createSequelize6Instance } from '../setup/create-sequelize-instance';
-import { expect } from 'chai';
-import sinon from 'sinon';
+import { createSequelize6Instance } from '../setup/create-sequelize-instance'
+import { Model, Column, DataType, ForeignKey, PrimaryKey, HasMany, Table } from "sequelize-typescript"
+import { expect } from 'chai'
+import sinon from 'sinon'
 
 // if your issue is dialect specific, remove the dialects you don't need to test on.
-export const testingOnDialects = new Set(['mssql', 'sqlite', 'mysql', 'mariadb', 'postgres', 'postgres-native']);
+export const testingOnDialects = new Set(['mssql', 'sqlite', 'mysql', 'mariadb', 'postgres', 'postgres-native'])
 
-// You can delete this file if you don't want your SSCCE to be tested against Sequelize 6
+@Table
+class ModelA extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.STRING })
+  id!: string
 
-// Your SSCCE goes inside this function.
-export async function run() {
-  // This function should be used instead of `new Sequelize()`.
-  // It applies the config for your SSCCE to work on CI.
+  @HasMany(() => ModelB)
+  bValues: ModelB[] | undefined
+}
+
+@Table
+class ModelB extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.DATE(6) })
+  date!: Date
+
+  @ForeignKey(() => ModelA)
+  @Column({ type: DataType.STRING })
+  idA!: string
+}
+
+export async function run () {
   const sequelize = createSequelize6Instance({
     logQueryParameters: true,
     benchmark: true,
     define: {
       // For less clutter in the SSCCE
       timestamps: false,
-    },
-  });
+    }
+  })
 
-  class Foo extends Model {}
+  await sequelize.addModels([ModelA, ModelB])
+  await sequelize.sync({ force: true })
+  await ModelA.create({ id: "id1" })
+  await ModelB.create({ idA: "id1", date: new Date('2023-03-07T00:00:00.111') })
+  await ModelB.create({ idA: "id1", date: new Date('2023-03-07T00:00:00.222') })
+  await ModelB.create({ idA: "id1", date: new Date('2023-03-07T00:00:01.333') })
 
-  Foo.init({
-    name: DataTypes.TEXT,
-  }, {
-    sequelize,
-    modelName: 'Foo',
-  });
+  const directQueryResult = await ModelB.findAll({
+    where: { idA: "id1" }
+  })
 
-  // You can use sinon and chai assertions directly in your SSCCE.
-  const spy = sinon.spy();
-  sequelize.afterBulkSync(() => spy());
-  await sequelize.sync({ force: true });
-  expect(spy).to.have.been.called;
+  expect(directQueryResult!.length, 'querying from model A').to.equal(3) // success
+  expect(directQueryResult[0].date.getMilliseconds()).to.equal(111) // success
+  expect(directQueryResult[1].date.getMilliseconds()).to.equal(222) // success
+  expect(directQueryResult[2].date.getMilliseconds()).to.equal(333) // success
 
-  console.log(await Foo.create({ name: 'TS foo' }));
-  expect(await Foo.count()).to.equal(1);
+  const includeQueryResult = await ModelA.findOne({
+    where: { id: "id1" },
+    include: {
+      model: ModelB
+    }
+  })
+
+  expect(includeQueryResult!.bValues![0].date.getMilliseconds()).to.equal(111) // success
+  expect(includeQueryResult!.bValues!.length, 'using include on model B').to.equal(3) // fails
+  expect(includeQueryResult!.bValues![1].date.getMilliseconds()).to.equal(222) // fails
+  expect(includeQueryResult!.bValues![2].date.getMilliseconds()).to.equal(333) // fails
 }

--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -1,15 +1,16 @@
-import { DataTypes, Model } from '@sequelize/core';
-import { createSequelize7Instance } from '../setup/create-sequelize-instance';
-import { expect } from 'chai';
-import sinon from 'sinon';
+// @ts-nocheck
+import { DataTypes, Model } from '@sequelize/core'
+import { createSequelize7Instance } from '../setup/create-sequelize-instance'
+import { expect } from 'chai'
+import sinon from 'sinon'
 
 // if your issue is dialect specific, remove the dialects you don't need to test on.
-export const testingOnDialects = new Set(['mssql', 'sqlite', 'mysql', 'mariadb', 'postgres', 'postgres-native']);
+export const testingOnDialects = new Set(['mssql', 'sqlite', 'mysql', 'mariadb', 'postgres', 'postgres-native'])
 
 // You can delete this file if you don't want your SSCCE to be tested against Sequelize 7
 
 // Your SSCCE goes inside this function.
-export async function run() {
+export async function run () {
   // This function should be used instead of `new Sequelize()`.
   // It applies the config for your SSCCE to work on CI.
   const sequelize = createSequelize7Instance({
@@ -19,23 +20,56 @@ export async function run() {
       // For less clutter in the SSCCE
       timestamps: false,
     },
-  });
+  })
 
-  class Foo extends Model {}
+  const ModelA = sequelize.define('ModelA', {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true
+    }
+  })
 
-  Foo.init({
-    name: DataTypes.TEXT,
-  }, {
-    sequelize,
-    modelName: 'Foo',
-  });
+  const ModelB = sequelize.define('ModelB', {
+    date: {
+      type: DataTypes.DATE(6),
+      primaryKey: true
+    },
+    ModelAId: {
+      type: DataTypes.STRING,
+      references: {
+        model: ModelA,
+        key: 'id',
+      }
+    }
+  })
 
-  // You can use sinon and chai assertions directly in your SSCCE.
-  const spy = sinon.spy();
-  sequelize.afterBulkSync(() => spy());
-  await sequelize.sync({ force: true });
-  expect(spy).to.have.been.called;
+  ModelA.hasMany(ModelB)
 
-  console.log(await Foo.create({ name: 'TS foo' }));
-  expect(await Foo.count()).to.equal(1);
+  await sequelize.sync({ force: true })
+
+  await ModelA.create({ id: "id1" })
+  await ModelB.create({ ModelAId: "id1", date: new Date('2023-03-07T00:00:00.111') })
+  await ModelB.create({ ModelAId: "id1", date: new Date('2023-03-07T00:00:00.222') })
+  await ModelB.create({ ModelAId: "id1", date: new Date('2023-03-07T00:00:01.333') })
+
+  const directQueryResult = await ModelB.findAll({
+    where: { ModelAId: "id1" }
+  })
+
+  expect(directQueryResult!.length, 'querying from model A').to.equal(3) // success
+  expect(directQueryResult[0].date.getMilliseconds()).to.equal(111) // success
+  expect(directQueryResult[1].date.getMilliseconds()).to.equal(222) // success
+  expect(directQueryResult[2].date.getMilliseconds()).to.equal(333) // success
+
+  const includeQueryResult = await ModelA.findOne({
+    where: { id: "id1" },
+    include: {
+      model: ModelB
+    }
+  })
+
+  expect(includeQueryResult!.ModelBs[0].date.getMilliseconds()).to.equal(111) // success
+  expect(includeQueryResult!.ModelBs!.length, 'using include on model B').to.equal(3) // fails
+  expect(includeQueryResult!.ModelBs[1].date.getMilliseconds()).to.equal(222) // fails
+  expect(includeQueryResult!.ModelBs[2].date.getMilliseconds()).to.equal(333) // fails
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "setup/*"
   ],
   "compilerOptions": {
+    "experimentalDecorators": true,
     "target": "es2021",
     "module": "CommonJS",
     "moduleResolution": "Node",


### PR DESCRIPTION
#16103