### PR TITLE
fix: make CI pipeline run v7 on Node.js >= 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         # node 10 is the minimum supported version for Sequelize 6
-        # node 14 is the minimum supported version for Sequelize 7
-        # node 16 is latest LTS (to keep updated)
+        # node 16 is the minimum supported version for Sequelize 7
+        # node 18 is latest LTS (to keep updated)
         node: [10, 14, 16]
     name: SQLite (sequelize 6 & 7, node ${{ matrix.node }})
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node }}
       - run: /bin/bash ./setup/prepare-ci.sh
       - name: Execute SSCCE
         run: npm run _test

--- a/setup/runner.ts
+++ b/setup/runner.ts
@@ -47,7 +47,7 @@ async function wrappedRun() {
     logBlue(heading);
     logBlue(`${'-'.repeat(heading.length)}\n`);
 
-    if (majorNodeVersion >= 14) {
+    if (majorNodeVersion >= 16) {
       const { run, testingOnDialects } = require('../src/sscce-sequelize-7');
       if (!testingOnDialects.has(process.env.DIALECT!)) {
         logRed(`Skipping dialect ${process.env.DIALECT} as it has been omitted from 'testingOnDialects'`);


### PR DESCRIPTION
With sequelize/sequelize#16058 v14 is no longer supported on Sequelize v7.  Update the CI pipeline to only run v7 tests if Node.js version is 16 or higher.

Also fix sqlite tests only being ran on Node.js v14.

Resolves sequelize/sequelize#16434