### PR TITLE
Update TS Config to support new decorators model definition

### DIFF
--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -1,4 +1,4 @@
-import { CreationOptional, DataTypes, Model } from '@sequelize/core';
+import { CreationOptional, DataTypes, InferAttributes, InferCreationAttributes, Model } from '@sequelize/core';
 import {
   Attribute,
   AutoIncrement,
@@ -27,20 +27,7 @@ export async function run() {
     },
   });
 
-  class Foo extends Model {}
-
-  Foo.init({
-    name: DataTypes.TEXT,
-  }, {
-    sequelize,
-    modelName: 'Foo',
-  });
-
-  // You can also use the new decorators model definition
-  class Bar extends Model {
-    @Attribute(DataTypes.INTEGER)
-    @PrimaryKey
-    @AutoIncrement
+  class Foo extends Model<InferAttributes<Foo>, InferCreationAttributes<Foo>> {
     declare id: CreationOptional<number>;
 
     @Attribute(DataTypes.TEXT)
@@ -48,7 +35,7 @@ export async function run() {
     declare name: string;
   }
 
-  sequelize.addModels([Bar]);
+  sequelize.addModels([Foo]);
 
   // You can use sinon and chai assertions directly in your SSCCE.
   const spy = sinon.spy();

--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -1,10 +1,5 @@
 import { CreationOptional, DataTypes, InferAttributes, InferCreationAttributes, Model } from '@sequelize/core';
-import {
-  Attribute,
-  AutoIncrement,
-  NotNull,
-  PrimaryKey,
-} from '@sequelize/core/decorators-legacy';
+import { Attribute, NotNull } from '@sequelize/core/decorators-legacy';
 import { createSequelize7Instance } from '../dev/create-sequelize-instance';
 import { expect } from 'chai';
 import sinon from 'sinon';

--- a/src/sscce-sequelize-7.ts
+++ b/src/sscce-sequelize-7.ts
@@ -1,4 +1,10 @@
-import { DataTypes, Model } from '@sequelize/core';
+import { CreationOptional, DataTypes, Model } from '@sequelize/core';
+import {
+  Attribute,
+  AutoIncrement,
+  NotNull,
+  PrimaryKey,
+} from '@sequelize/core/decorators-legacy';
 import { createSequelize7Instance } from '../dev/create-sequelize-instance';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -29,6 +35,20 @@ export async function run() {
     sequelize,
     modelName: 'Foo',
   });
+
+  // You can also use the new decorators model definition
+  class Bar extends Model {
+    @Attribute(DataTypes.INTEGER)
+    @PrimaryKey
+    @AutoIncrement
+    declare id: CreationOptional<number>;
+
+    @Attribute(DataTypes.TEXT)
+    @NotNull
+    declare name: string;
+  }
+
+  sequelize.addModels([Bar]);
 
   // You can use sinon and chai assertions directly in your SSCCE.
   const spy = sinon.spy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
   ],
   "compilerOptions": {
     "target": "es2021",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "experimentalDecorators": true,
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "newLine": "lf",


### PR DESCRIPTION
Redo of #267:

Based on [this issue](https://github.com/sequelize/website/issues/552) and [this issue](https://github.com/sequelize/sequelize/issues/16866).

Update `tsconfig.json`:
- Add support for `experimentalDecorators`
- Bump module and moduleResolution to import `@sequelize/core/decorators-legacy` declarations properly

Update `sscce-sequelize-7.ts`:
- Add new Bar model to demonstrate new model definition example with decorators